### PR TITLE
Update ar6700.baf

### DIFF
--- a/DSotSC/modify/bcs/ar6700.baf
+++ b/DSotSC/modify/bcs/ar6700.baf
@@ -7,8 +7,7 @@ THEN
 	RESPONSE #100
 		CreateCreature("DSBLANE",[4601.3033],6)
 		SetGlobal("BlaneSpawn","%Beregost%",1)
-		ActionOverride("DSBLANE",SetDialog("BLANE")) //why?
-END
+		END
 
 IF
 	Global("FindRelic","GLOBAL",1)


### PR DESCRIPTION
The dialogue change makes no sense but can lead to bugs because a wrong state from the Blane.dlg may be triggered. Blane.dlg is modified as well by other mods using Beregost Temple Vestibule which adds to the possibility of unwanted states triggering. The use of DSBlane.dlg which is attached to the cre file is sufficient.

In the same context the line
COMPILE DSotSC/modify/dlg/blane.d EVALUATE_BUFFER in TP2 makes no sense, especially since it does not use WEIGHT to assure the correct states to trigger.