### PR TITLE
Fixed incorrect use of ENGINE_IS eet and updated changes list

### DIFF
--- a/DSotSC/DSotSC.tp2
+++ b/DSotSC/DSotSC.tp2
@@ -64,7 +64,6 @@ ALWAYS
 		OUTER_SPRINT GibberlingMountains_entrance ~EXIT4600~ //patching ARE
 
 		OUTER_SPRINT ~LARGE~ ~M~ //for correct portrait assignment
-
 	END ELSE ACTION_IF GAME_IS ~eet~ BEGIN
 		INCLUDE ~DSotSC/lib/eet_cpmvars.tpa~
 		OUTER_SPRINT platform ~eet~
@@ -79,29 +78,29 @@ ALWAYS
 
 	INCLUDE ~DSotSC/lib/macros.tpa~
 
-	ACTION_IF ENGINE_IS ~bgee bg2ee eet~ BEGIN
-			ACTION_DEFINE_ASSOCIATIVE_ARRAY charsetsTable BEGIN
-				"german" => "CP1252"
-				"english" => "CP1252"
-				"french" => "CP1252"
-				"italian" => "CP1252"
-				"polish" => "CP1250"
-				"russian" => "CP1251"
-				"castilian" => "CP1252"
-				"schinese" => "CP936"
-			END
-			ACTION_DEFINE_ARRAY charsetsReloadArray BEGIN setup soundsets journal END
-//			ACTION_DEFINE_ARRAY charsetsNoConvertArray BEGIN END
-			LAF ~HANDLE_CHARSETS~
-				INT_VAR
-				infer_charsets = 0
-				STR_VAR
-				tra_path = "DSotSC/language"
-				iconv_path = "DSotSC/bin/win32/iconv" //available as part of the base system on OS X and GNU/Linux
-				charset_table = charsetsTable
-				reload_array = charsetsReloadArray
-				noconvert_array = charsetsNoConvertArray
-			END
+	ACTION_IF ENGINE_IS ~bgee bg2ee~ BEGIN
+		ACTION_DEFINE_ASSOCIATIVE_ARRAY charsetsTable BEGIN
+			"german" => "CP1252"
+			"english" => "CP1252"
+			"french" => "CP1252"
+			"italian" => "CP1252"
+			"polish" => "CP1250"
+			"russian" => "CP1251"
+			"castilian" => "CP1252"
+			"schinese" => "CP936"
+		END
+		ACTION_DEFINE_ARRAY charsetsReloadArray BEGIN setup soundsets journal END
+		// ACTION_DEFINE_ARRAY charsetsNoConvertArray BEGIN END
+		LAF ~HANDLE_CHARSETS~
+			INT_VAR
+			infer_charsets = 0
+			STR_VAR
+			tra_path = "DSotSC/language"
+			iconv_path = "DSotSC/bin/win32/iconv" //available as part of the base system on OS X and GNU/Linux
+			charset_table = charsetsTable
+			reload_array = charsetsReloadArray
+			noconvert_array = charsetsNoConvertArray
+		END
 		LOAD_TRA ~DSotSC/language/%LANGUAGE%/setup.tra~
 		LOAD_TRA ~DSotSC/language/%LANGUAGE%/setup-ee.tra~
 	END

--- a/DSotSC/docs/changes.txt
+++ b/DSotSC/docs/changes.txt
@@ -1,7 +1,14 @@
-Version 4.5 (by 11jo)
+Version 4.3
+By 11jo:
 - French translation by Isaya and Mornagest
 - Add french soundset from IWD
+By Graion Dilach:
 - Fix Cure Moderate Wounds being installed as it's counterpart
+- Update Infinity Auto Packager
+By Lzw104522773:
+- Upload Simplified Chinese translation
+By Roberciiik:
+- Fix ENGINE_IS inconsistency
 
 Version 4.2 (by Graion Dilach)
 - better spell compatibility against SoD/EET, SR and IWDification


### PR DESCRIPTION
`ENGINE_IS ~eet~` is an unsupported value, as it is a game type, not the engine itself. Removed confusing statement.